### PR TITLE
[PC-14-01] fix: restore dragging functionality after a change in Chrome 138 

### DIFF
--- a/addon/utils/css-calculation.js
+++ b/addon/utils/css-calculation.js
@@ -8,7 +8,8 @@
 */
 export function getBorderSpacing(el) {
   let css = getComputedStyle(el).borderSpacing; // '0px 0px'
-  let [horizontal, vertical] = css.split(' ');
+  let [horizontal, initialVertical] = css.split(' ');
+  let vertical = initialVertical === undefined ? horizontal : initialVertical;
 
   return {
     horizontal: parseFloat(horizontal),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gynzy/ember-sortable",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "description": "Sortable UI primitives for Ember.",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
# Description

Fixed in master (earlier for Firefox) in https://github.com/adopted-ember-addons/ember-sortable/commit/96f0116a27b91563ac367345ee84d1ee54ef459c. Could not be cherry-picked since the upstream repo has been converted to TypeScript since our fork was created.